### PR TITLE
Ariane Explorer field: match Ariane's native encoding (fixes raw markup in data table)

### DIFF
--- a/openspeleo_lib/interfaces/ariane/decoding.py
+++ b/openspeleo_lib/interfaces/ariane/decoding.py
@@ -83,10 +83,16 @@ def ariane_decode(data: dict) -> dict:  # noqa: PLR0915
             section_surveyors = ""
 
             # ==================== Explorers / Surveyors ==================== #
-            # Ariane Version >= 26
-            if any(key in shot for key in ["explorers", "surveyors"]):
-                section_explorers = shot.pop("explorers", "")
-                section_surveyors = shot.pop("surveyors", "")
+            # Ariane Version >= 26 - or files written by this library, which
+            # always carry the split in XMLExplorer/XMLSurveyor
+            if any(
+                key in shot
+                for key in ["explorers", "surveyors", "XMLExplorer", "XMLSurveyor"]
+            ):
+                _xml_explorers = shot.pop("XMLExplorer", "") or ""
+                _xml_surveyors = shot.pop("XMLSurveyor", "") or ""
+                section_explorers = shot.pop("explorers", "") or _xml_explorers
+                section_surveyors = shot.pop("surveyors", "") or _xml_surveyors
 
                 with contextlib.suppress(KeyError):
                     del shot["Explorer"]

--- a/openspeleo_lib/interfaces/ariane/encoding.py
+++ b/openspeleo_lib/interfaces/ariane/encoding.py
@@ -31,24 +31,20 @@ def ariane_encode(data: dict) -> dict:
             shot["Date"] = section["date"]
 
             # ~~~~~~~~~~~~~~~~ Processing Explorers/Surveyors ~~~~~~~~~~~~~~~ #
-            shot["XMLExplorer"] = ",".join(section["explorers"])
-            shot["XMLSurveyor"] = ",".join(section["surveyors"])
-
-            # ----------------- Legacy backport: Ariane < 26 ---------------- #
-            _explo_data = {}
-            for dest_key, orig_key in [
-                ("Explorer", "explorers"),
-                ("Surveyor", "surveyors"),
-            ]:
-                if _value := section.get(orig_key, ""):
-                    _explo_data[dest_key] = ",".join(_value)
-
-            # In case only "explorer" data exists - Ariane doesn't store in format XML
-            if len(_explo_data) == 1:
-                with contextlib.suppress(KeyError):
-                    _explo_data = ",".join(_explo_data["explorers"])
-
-            shot["Explorer"] = serialize_dict_to_xmlfield(_explo_data)
+            # Ariane stores this field as an escaped embedded fragment with
+            # BOTH tags, even when one is empty (see
+            # tests/artifacts/hand_survey.tml, authored by Ariane itself):
+            #     <Explorer>E</Explorer><Surveyor>S</Surveyor>
+            # Any deviation - a Surveyor-only fragment (previous behavior when
+            # explorers was empty), a bare string, or extra XMLExplorer /
+            # XMLSurveyor sibling tags - is rendered by Ariane as literal text
+            # in the data table's Explorer column.
+            shot["Explorer"] = serialize_dict_to_xmlfield(
+                {
+                    "Explorer": ",".join(section["explorers"]),
+                    "Surveyor": ",".join(section["surveyors"]),
+                }
+            )
             # --------------------------------------------------------------- #
 
             # # Reverse Color standardization

--- a/openspeleo_lib/interfaces/ariane/encoding.py
+++ b/openspeleo_lib/interfaces/ariane/encoding.py
@@ -47,9 +47,14 @@ def ariane_encode(data: dict) -> dict:
             )
             # --------------------------------------------------------------- #
 
-            # # Reverse Color standardization
-            # print(f"{shot["Color"]=}")
-            # shot["Color"] = shot.pop("Color").replace("#", "0x")
+            # Color standardization: Ariane-authored files use 0xrrggbbaa;
+            # the model's CSS-style default (#FFB366) is not an Ariane format.
+            color = shot.get("Color")
+            if isinstance(color, str) and color.startswith("#"):
+                hex_part = color[1:].lower()
+                if len(hex_part) == 6:
+                    hex_part += "ff"  # opaque, as on Ariane-authored shots
+                shot["Color"] = f"0x{hex_part}"
 
             shots.append(shot)
 

--- a/tests/interfaces/ariane/test_color_format.py
+++ b/tests/interfaces/ariane/test_color_format.py
@@ -1,0 +1,51 @@
+"""Ariane-authored files store shot colors as `0xrrggbbaa` (see
+tests/artifacts/hand_survey.tml, test_simple.tml, test_ariane_v26.tml — no
+Ariane file uses CSS-style `#RRGGBB`). Model-built surveys carry the CSS-style
+default and must be normalized on export."""
+
+import zipfile
+
+from openspeleo_lib.generators import UniqueValueGenerator
+from openspeleo_lib.interfaces import ArianeInterface
+from openspeleo_lib.interfaces.ariane.interface import ArianeSurvey
+
+
+def _survey():
+    data = {
+        "name": "color-test",
+        "unit": "FT",
+        "sections": [
+            {
+                "name": "S1", "survey": None, "date": "2024-02-23",
+                "explorers": [], "surveyors": [],
+                "shots": [
+                    {"id_stop": 0, "section": None, "shot_type": "START",
+                     "name": "E", "length": 0.0, "depth": 0.0, "azimuth": 0.0},
+                    {"id_start": 0, "id_stop": 1, "section": None, "name": "S1",
+                     "length": 10.0, "depth": 0.0, "azimuth": 90.0,
+                     "color": "#FFB366"},
+                ],
+            }
+        ],
+    }
+    with UniqueValueGenerator.activate_uniqueness():
+        return ArianeSurvey.model_validate(data)
+
+
+def test_css_colors_normalized_to_ariane_format(tmp_path):
+    out = tmp_path / "out.tml"
+    ArianeInterface.to_file(_survey(), out)
+    with zipfile.ZipFile(out) as z:
+        xml = z.read("Data.xml").decode()
+    assert "<Color>0xffb366ff</Color>" in xml
+    assert "<Color>#" not in xml
+
+
+def test_ariane_native_colors_pass_through(tmp_path):
+    survey = _survey()
+    survey.sections[0].shots[1].color = "0x8f6112ff"
+    out = tmp_path / "out.tml"
+    ArianeInterface.to_file(survey, out)
+    with zipfile.ZipFile(out) as z:
+        xml = z.read("Data.xml").decode()
+    assert "<Color>0x8f6112ff</Color>" in xml

--- a/tests/interfaces/ariane/test_explorer_field.py
+++ b/tests/interfaces/ariane/test_explorer_field.py
@@ -1,0 +1,72 @@
+"""The `Explorer` field must match Ariane's native encoding: an escaped
+embedded fragment carrying BOTH tags, exactly as Ariane itself writes it
+(tests/artifacts/hand_survey.tml):
+
+    <Explorer>&lt;Explorer&gt;E&lt;/Explorer&gt;&lt;Surveyor&gt;S&lt;/Surveyor&gt;</Explorer>
+
+The previous Surveyor-only fragment (produced whenever `explorers` was empty)
+and the XMLExplorer/XMLSurveyor sibling tags are rendered by Ariane as literal
+text in the data table's Explorer column.
+"""
+
+import zipfile
+
+import pytest
+
+from openspeleo_lib.generators import UniqueValueGenerator
+from openspeleo_lib.interfaces import ArianeInterface
+from openspeleo_lib.interfaces.ariane.interface import ArianeSurvey
+
+
+@pytest.fixture
+def survey_surveyors_only():
+    data = {
+        "name": "explorer-field-test",
+        "unit": "FT",
+        "sections": [
+            {
+                "name": "S1",
+                "survey": None,
+                "date": "2024-02-23",
+                "explorers": [],
+                "surveyors": ["A. Pitkin & C. Roberson", "Guy Bryant"],
+                "shots": [
+                    {
+                        "id_stop": 0, "section": None, "shot_type": "START",
+                        "name": "E", "length": 0.0, "depth": 0.0, "azimuth": 0.0,
+                    },
+                    {
+                        "id_start": 0, "id_stop": 1, "section": None, "name": "S1",
+                        "length": 10.0, "depth": 0.0, "azimuth": 90.0,
+                    },
+                ],
+            }
+        ],
+    }
+    with UniqueValueGenerator.activate_uniqueness():
+        return ArianeSurvey.model_validate(data)
+
+
+def test_explorer_field_native_both_tags(survey_surveyors_only, tmp_path):
+    out = tmp_path / "out.tml"
+    ArianeInterface.to_file(survey_surveyors_only, out)
+
+    with zipfile.ZipFile(out) as z:
+        xml = z.read("Data.xml").decode()
+
+    # both tags present even though explorers is empty - matching Ariane
+    assert (
+        "<Explorer>&lt;Explorer&gt;&lt;/Explorer&gt;"
+        "&lt;Surveyor&gt;A. Pitkin &amp;amp; C. Roberson,Guy Bryant"
+        "&lt;/Surveyor&gt;</Explorer>"
+    ) in xml
+    # no Ariane-foreign sibling tags
+    assert "XMLExplorer" not in xml
+    assert "XMLSurveyor" not in xml
+
+
+def test_surveyors_round_trip(survey_surveyors_only, tmp_path):
+    out = tmp_path / "out.tml"
+    ArianeInterface.to_file(survey_surveyors_only, out)
+    back = ArianeInterface.from_file(out)
+    assert back.sections[0].surveyors == ["A. Pitkin & C. Roberson", "Guy Bryant"]


### PR DESCRIPTION
## Problems

Two ways files written by this library deviate from what Ariane itself writes, both visible in Ariane's UI:

### 1. Explorer field shows raw markup in the data table

```
<Surveyor>Guy Bryant,Jean Nelson</Surveyor><Explorer></Explorer>...
```

Compared against Ariane-authored files (`tests/artifacts/hand_survey.tml`), Ariane's storage form is an escaped embedded fragment with **both** tags, always: `<Explorer>E</Explorer><Surveyor>S</Surveyor>`. The encoder deviates twice:

- When `explorers` is empty (the common case), the `len(_explo_data) == 1` branch collapses the fragment to `<Surveyor>…</Surveyor>` only. (That branch also references `_explo_data["explorers"]`, a key that never exists, so its string-collapse path is dead code guarded by `suppress(KeyError)`.)
- `XMLExplorer`/`XMLSurveyor` sibling tags are written on every shot; they appear in no Ariane-authored file, and current Ariane concatenates them into the Explorer column as literal `<Explorer></Explorer><Surveyor>…</Surveyor>` text (screenshot-verified).

### 2. Shot colors are written CSS-style

Every Ariane-authored artifact stores `<Color>0xrrggbbaa</Color>`; the model default is `#FFB366` and reaches the file unconverted. (The fix revives the commented-out "Reverse Color standardization" block.)

## Fixes

- `ariane_encode`: always serialize `{"Explorer": …, "Surveyor": …}` — both tags, matching `hand_survey.tml`; stop writing `XMLExplorer`/`XMLSurveyor`.
- `ariane_decode`: additionally read `XMLExplorer`/`XMLSurveyor` so files written by previous versions of this library keep their explorer/surveyor split.
- `ariane_encode`: normalize `#RRGGBB[AA]` colors to `0xrrggbb[aa]` (6-digit colors get opaque `ff` alpha, as on Ariane-authored shots); native `0x` colors pass through untouched.

## Display caveat, verified on the latest Ariane (2026-07)

The data table renders the Explorer field as **raw storage text** even for the native both-tags form — Ariane-authored files display as `<Explorer>E</Explorer><Surveyor>S</Surveyor>` in that column too. The only form that renders as clean names is a bare string, which older Ariane wrote (`test_simple.tml` stores plain `Ariane`). If display cleanliness is preferred over preserving the explorer/surveyor split (plain text folds both into one list on re-read, which would require adjusting the round-trip fidelity tests), I'm happy to rework — maintainer's call; this PR takes the format-faithful option.

## Tests

- `tests/interfaces/ariane/test_explorer_field.py`: native both-tags form (empty explorers included), no sibling tags, exact surveyor round-trip with an ampersand.
- `tests/interfaces/ariane/test_color_format.py`: CSS default normalizes to `0xffb366ff`; native `0x` colors untouched.
- `tests/interfaces` + `tests/models`: 52/52 pass. The two `test_command_validate_tml` failures on my machine are pre-existing on `main` (Python 3.14 colorized argparse/traceback output) and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ddTS1aKThUMNnYHBr8Mrc